### PR TITLE
fix(i-reroute): remove Cloudflare tags annotation from service since …

### DIFF
--- a/infra/configs/base/i-reroute/service.yaml
+++ b/infra/configs/base/i-reroute/service.yaml
@@ -4,7 +4,6 @@ metadata:
   name: i-reroute
   annotations:
     external-dns.alpha.kubernetes.io/cloudflare-proxied: "false" # Disable Cloudflare proxy for this service
-    external-dns.alpha.kubernetes.io/cloudflare-tags: "Managed by external-dns from i-reroute service"
     # MUST be patched
     external-dns.alpha.kubernetes.io/hostname: "*.i.clustername.isning.moe,*.i.isning.moe,*.i.staging.isning.moe" # Set the desired hostnames for External DNS
 spec:


### PR DESCRIPTION
…it's too long

DNS record tag name "managed by external-dns from i-reroute service" exceeds the maximum length of 32 characters.