### PR TITLE
fix(grafana): align GrafanaDashboard datasource mapping with live CRD…

### DIFF
--- a/apps/base/speaches/dashboard.yaml
+++ b/apps/base/speaches/dashboard.yaml
@@ -12,9 +12,20 @@ spec:
         "title": "Speaches Overview",
         "tags": ["speaches", "application"],
         "timezone": "browser",
+        "__inputs": [
+          {
+            "name": "DS_PROMETHEUS",
+            "label": "Prometheus",
+            "description": "",
+            "type": "datasource",
+            "pluginId": "prometheus",
+            "pluginName": "Prometheus"
+          }
+        ],
         "panels": [
           {
             "title": "CPU Usage",
+            "datasource": "${DS_PROMETHEUS}",
             "targets": [
               {
                 "expr": "rate(container_cpu_usage_seconds_total{pod=~\"speaches.*\"}[5m]) * 100",
@@ -26,6 +37,7 @@ spec:
           },
           {
             "title": "Memory Usage",
+            "datasource": "${DS_PROMETHEUS}",
             "targets": [
               {
                 "expr": "container_memory_usage_bytes{pod=~\"speaches.*\"} / 1024 / 1024",
@@ -37,6 +49,7 @@ spec:
           },
           {
             "title": "Request Rate",
+            "datasource": "${DS_PROMETHEUS}",
             "targets": [
               {
                 "expr": "rate(http_requests_total{job=\"speaches\"}[5m])",
@@ -48,6 +61,7 @@ spec:
           },
           {
             "title": "Request Duration (p95)",
+            "datasource": "${DS_PROMETHEUS}",
             "targets": [
               {
                 "expr": "histogram_quantile(0.95, rate(http_request_duration_seconds_bucket{job=\"speaches\"}[5m]))",
@@ -63,6 +77,6 @@ spec:
         "version": 0
       }
     }
-  datasource:
-    inputName: "DS_PROMETHEUS"
-    value: VictoriaMetrics
+  datasources:
+    - inputName: "DS_PROMETHEUS"
+      datasourceName: "VictoriaMetrics"


### PR DESCRIPTION
… schema

- Replace unsupported spec.datasource with spec.datasources
- Use DS_PROMETHEUS input mapping to VictoriaMetrics datasourceName
- Bind panel datasource to  in dashboard JSON