### PR TITLE
feat(harbor): add proxy-cache bootstrap and node mirror templates

### DIFF
--- a/infra/configs/base/istio/httproutes/harbor.yaml
+++ b/infra/configs/base/istio/httproutes/harbor.yaml
@@ -1,0 +1,19 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: harbor
+  namespace: harbor
+spec:
+  parentRefs:
+    - name: infra-gateway
+      namespace: kube-system
+  hostnames:
+    - "harbor.isning.moe"
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: harbor
+          port: 80

--- a/infra/controllers/base/harbor/helm-release.yaml
+++ b/infra/controllers/base/harbor/helm-release.yaml
@@ -1,0 +1,54 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: harbor
+  namespace: harbor
+spec:
+  releaseName: harbor
+  interval: 30m
+  chart:
+    spec:
+      chart: harbor
+      sourceRef:
+        kind: HelmRepository
+        name: harbor
+        namespace: flux-system
+      version: "1.*"
+      interval: 12h
+  values:
+    expose:
+      type: clusterIP
+      tls:
+        enabled: false
+    externalURL: https://harbor.isning.moe
+
+    # Route Harbor's outbound requests through the cluster egress proxy.
+    proxy:
+      httpProxy: http://proxy-svc.egress-system.svc.cluster.local:7890
+      httpsProxy: http://proxy-svc.egress-system.svc.cluster.local:7890
+      noProxy: 127.0.0.1,localhost,.svc,.cluster.local,harbor.harbor.svc,core,jobservice,registry,portal
+
+    # Keep internal dependencies for simpler bootstrap.
+    database:
+      type: internal
+    redis:
+      type: internal
+
+    # Disable scanners to reduce footprint; can be enabled later.
+    trivy:
+      enabled: false
+
+    persistence:
+      enabled: true
+      resourcePolicy: keep
+      persistentVolumeClaim:
+        registry:
+          size: 100Gi
+        jobservice:
+          jobLog:
+            size: 5Gi
+        database:
+          size: 10Gi
+        redis:
+          size: 5Gi

--- a/infra/controllers/base/harbor/helm-repo.yaml
+++ b/infra/controllers/base/harbor/helm-repo.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: harbor
+  namespace: flux-system
+spec:
+  interval: 12h
+  url: https://helm.goharbor.io

--- a/infra/controllers/base/harbor/kustomization.yaml
+++ b/infra/controllers/base/harbor/kustomization.yaml
@@ -2,6 +2,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ./grafana-loki.yaml
-  - ./harbor.yaml
-  - ./vmagent.yaml
+  - ./helm-repo.yaml
+  - ./helm-release.yaml

--- a/infra/controllers/overlays/kubevirt-lab-1/kustomization.yaml
+++ b/infra/controllers/overlays/kubevirt-lab-1/kustomization.yaml
@@ -12,6 +12,7 @@ resources:
   - ../../base/kubevirt/
   - ../../base/cloudflare-operator/
   - ../../base/external-dns/
+  - ../../base/harbor/
   - ../../base/generic-helm-repos/
   - ../../base/cloudnative-pg/
   - ../../base/redroid-operator/

--- a/infra/namespaces/controllers.yaml
+++ b/infra/namespaces/controllers.yaml
@@ -37,6 +37,11 @@ metadata:
 apiVersion: v1
 kind: Namespace
 metadata:
+  name: harbor
+---
+apiVersion: v1
+kind: Namespace
+metadata:
   name: kiali-operator
 ---
 apiVersion: v1

--- a/scripts/harbor_init_proxy_cache.py
+++ b/scripts/harbor_init_proxy_cache.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+"""Initialize Harbor proxy cache registries and projects.
+
+Usage:
+  HARBOR_PASSWORD=... python3 scripts/harbor_init_proxy_cache.py \
+    --harbor-url https://harbor.isning.moe \
+    --username admin \
+    --config scripts/harbor_proxy_cache_config.example.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from typing import Any
+
+
+def _request_json(
+    method: str,
+    url: str,
+    username: str,
+    password: str,
+    payload: dict[str, Any] | None = None,
+    accepted_codes: tuple[int, ...] = (200,),
+) -> Any:
+    data = None
+    if payload is not None:
+        data = json.dumps(payload).encode("utf-8")
+
+    req = urllib.request.Request(url=url, method=method, data=data)
+    req.add_header("Accept", "application/json")
+    req.add_header("Content-Type", "application/json")
+
+    # Basic auth header
+    credentials = f"{username}:{password}".encode("utf-8")
+    import base64
+
+    req.add_header("Authorization", "Basic " + base64.b64encode(credentials).decode("ascii"))
+
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            if resp.status not in accepted_codes:
+                raise RuntimeError(f"Unexpected status {resp.status} for {method} {url}")
+            body = resp.read().decode("utf-8")
+            return json.loads(body) if body else None
+    except urllib.error.HTTPError as exc:
+        if exc.code in accepted_codes:
+            body = exc.read().decode("utf-8") if exc.fp else ""
+            return json.loads(body) if body else None
+        detail = exc.read().decode("utf-8") if exc.fp else ""
+        raise RuntimeError(f"HTTP {exc.code} on {method} {url}: {detail}") from exc
+
+
+def _list_registries(base_url: str, username: str, password: str) -> list[dict[str, Any]]:
+    url = f"{base_url}/api/v2.0/registries?page=1&page_size=200"
+    return _request_json("GET", url, username, password, accepted_codes=(200,))
+
+
+def _list_projects(base_url: str, username: str, password: str) -> list[dict[str, Any]]:
+    url = f"{base_url}/api/v2.0/projects?page=1&page_size=500&with_detail=true"
+    return _request_json("GET", url, username, password, accepted_codes=(200,))
+
+
+def _find_registry_id(registries: list[dict[str, Any]], name: str) -> int | None:
+    for item in registries:
+        if item.get("name") == name:
+            return int(item["id"])
+    return None
+
+
+def _find_project(projects: list[dict[str, Any]], name: str) -> dict[str, Any] | None:
+    for item in projects:
+        if item.get("name") == name:
+            return item
+    return None
+
+
+def _create_registry(
+    base_url: str,
+    username: str,
+    password: str,
+    item: dict[str, Any],
+) -> None:
+    url = f"{base_url}/api/v2.0/registries"
+    payload: dict[str, Any] = {
+        "name": item["name"],
+        "type": item["provider"],
+        "url": item["endpoint"],
+        "insecure": bool(item.get("insecure", False)),
+    }
+
+    credential: dict[str, str] = {"type": item.get("credential_type", "basic")}
+    access_key_env = item.get("access_key_env")
+    access_secret_env = item.get("access_secret_env")
+    if access_key_env and access_secret_env:
+        access_key = os.getenv(access_key_env, "")
+        access_secret = os.getenv(access_secret_env, "")
+        if access_key and access_secret:
+            credential["access_key"] = access_key
+            credential["access_secret"] = access_secret
+
+    if len(credential) > 1:
+        payload["credential"] = credential
+
+    _request_json("POST", url, username, password, payload=payload, accepted_codes=(201, 409))
+
+
+def _create_project(
+    base_url: str,
+    username: str,
+    password: str,
+    item: dict[str, Any],
+    registry_id: int,
+) -> None:
+    url = f"{base_url}/api/v2.0/projects"
+    is_public = bool(item.get("public", True))
+    payload = {
+        "project_name": item["name"],
+        "registry_id": registry_id,
+        "metadata": {"public": "true" if is_public else "false"},
+        "storage_limit": int(item.get("storage_limit", -1)),
+    }
+    _request_json("POST", url, username, password, payload=payload, accepted_codes=(201, 409))
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Initialize Harbor proxy cache projects")
+    parser.add_argument("--harbor-url", required=True, help="Harbor base URL, e.g. https://harbor.example.com")
+    parser.add_argument("--username", default="admin", help="Harbor username")
+    parser.add_argument(
+        "--password",
+        default=os.getenv("HARBOR_PASSWORD", ""),
+        help="Harbor password (or set HARBOR_PASSWORD)",
+    )
+    parser.add_argument("--config", required=True, help="Path to JSON config file")
+    args = parser.parse_args()
+
+    if not args.password:
+        print("Error: missing Harbor password. Set --password or HARBOR_PASSWORD.", file=sys.stderr)
+        return 2
+
+    with open(args.config, "r", encoding="utf-8") as f:
+        config = json.load(f)
+
+    base_url = args.harbor_url.rstrip("/")
+
+    registry_items = config.get("registries", [])
+    project_items = config.get("projects", [])
+
+    if not registry_items:
+        print("No registries configured, nothing to do.")
+        return 0
+
+    # Step 1: create or reuse upstream registries
+    for item in registry_items:
+        name = item["name"]
+        registries = _list_registries(base_url, args.username, args.password)
+        registry_id = _find_registry_id(registries, name)
+        if registry_id is None:
+            print(f"Creating registry: {name}")
+            _create_registry(base_url, args.username, args.password, item)
+        else:
+            print(f"Registry already exists: {name} (id={registry_id})")
+
+    # Step 2: create proxy cache projects bound to registry ids
+    registries = _list_registries(base_url, args.username, args.password)
+    projects = _list_projects(base_url, args.username, args.password)
+
+    for item in project_items:
+        name = item["name"]
+        registry_name = item["registry"]
+        registry_id = _find_registry_id(registries, registry_name)
+        if registry_id is None:
+            raise RuntimeError(
+                f"Registry '{registry_name}' not found for project '{name}'. "
+                "Check config.registries entries."
+            )
+
+        if _find_project(projects, name) is not None:
+            print(f"Project already exists: {name}")
+            continue
+
+        print(f"Creating proxy cache project: {name} -> registry '{registry_name}' (id={registry_id})")
+        _create_project(base_url, args.username, args.password, item, registry_id)
+
+    print("Done.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/harbor_proxy_cache_config.example.json
+++ b/scripts/harbor_proxy_cache_config.example.json
@@ -1,0 +1,86 @@
+{
+  "registries": [
+    {
+      "name": "dockerhub-upstream",
+      "provider": "docker-hub",
+      "endpoint": "https://hub.docker.com",
+      "insecure": false,
+      "access_key_env": "DOCKERHUB_USERNAME",
+      "access_secret_env": "DOCKERHUB_TOKEN"
+    },
+    {
+      "name": "ghcr-upstream",
+      "provider": "github",
+      "endpoint": "https://ghcr.io",
+      "insecure": false,
+      "access_key_env": "GHCR_USERNAME",
+      "access_secret_env": "GHCR_TOKEN"
+    },
+    {
+      "name": "quay-upstream",
+      "provider": "quay",
+      "endpoint": "https://quay.io",
+      "insecure": false,
+      "access_key_env": "QUAY_USERNAME",
+      "access_secret_env": "QUAY_TOKEN"
+    },
+    {
+      "name": "k8s-registry-upstream",
+      "provider": "docker-registry",
+      "endpoint": "https://registry.k8s.io",
+      "insecure": false
+    },
+    {
+      "name": "gcr-upstream",
+      "provider": "gcr",
+      "endpoint": "https://gcr.io",
+      "insecure": false,
+      "access_key_env": "GCR_USERNAME",
+      "access_secret_env": "GCR_TOKEN"
+    },
+    {
+      "name": "mcr-upstream",
+      "provider": "docker-registry",
+      "endpoint": "https://mcr.microsoft.com",
+      "insecure": false
+    }
+  ],
+  "projects": [
+    {
+      "name": "dockerhub",
+      "registry": "dockerhub-upstream",
+      "public": false,
+      "storage_limit": -1
+    },
+    {
+      "name": "ghcr",
+      "registry": "ghcr-upstream",
+      "public": false,
+      "storage_limit": -1
+    },
+    {
+      "name": "quay",
+      "registry": "quay-upstream",
+      "public": false,
+      "storage_limit": -1
+    },
+    {
+      "name": "registry-k8s",
+      "registry": "k8s-registry-upstream",
+      "public": false,
+      "storage_limit": -1
+    },
+    {
+      "name": "gcr",
+      "registry": "gcr-upstream",
+      "public": false,
+      "storage_limit": -1
+    },
+    {
+      "name": "mcr",
+      "registry": "mcr-upstream",
+      "public": false,
+      "storage_limit": -1
+    }
+  ]
+}

--- a/scripts/templates/README-harbor-mirror.md
+++ b/scripts/templates/README-harbor-mirror.md
@@ -1,0 +1,67 @@
+# Harbor Mirror Templates
+
+This folder contains node-level mirror templates for Harbor proxy-cache.
+
+Files:
+
+- `k3s-registries.harbor.example.yaml`
+  - target path: `/etc/rancher/k3s/registries.yaml`
+- `containerd-hosts.harbor.example.toml`
+  - target path: `/etc/containerd/certs.d/<upstream-registry>/hosts.toml`
+
+Supported upstream registries and Harbor projects:
+
+- `docker.io` -> `dockerhub`
+- `ghcr.io` -> `ghcr`
+- `quay.io` -> `quay`
+- `registry.k8s.io` -> `registry-k8s`
+- `gcr.io` -> `gcr`
+- `k8s.gcr.io` -> `gcr`
+- `mcr.microsoft.com` -> `mcr`
+
+## k3s
+
+1. Copy template:
+
+```bash
+sudo cp scripts/templates/k3s-registries.harbor.example.yaml /etc/rancher/k3s/registries.yaml
+```
+
+2. Replace credentials placeholders:
+
+- `__HARBOR_USERNAME__`
+- `__HARBOR_PASSWORD__`
+
+3. Restart k3s:
+
+```bash
+sudo systemctl restart k3s
+```
+
+## containerd
+
+1. Create one `hosts.toml` per upstream registry:
+
+```bash
+sudo mkdir -p /etc/containerd/certs.d/docker.io
+sudo cp scripts/templates/containerd-hosts.harbor.example.toml /etc/containerd/certs.d/docker.io/hosts.toml
+```
+
+2. For each upstream registry, replace:
+
+- `__SERVER__` (example: `https://registry-1.docker.io`)
+- `__HARBOR_PROJECT__` (example: `dockerhub`)
+- `__BASE64_HARBOR_CREDENTIALS__` (`base64(username:password)`)
+
+3. Restart containerd:
+
+```bash
+sudo systemctl restart containerd
+```
+
+## Operational Notes
+
+- Use Harbor robot account with pull-only permission.
+- Keep proxy-cache projects private if your egress bandwidth is limited.
+- Plan yearly manual token rotation if you do not need high-frequency rotate.
+- If Harbor uses private CA, install CA cert on nodes and keep `skip_verify = false`.

--- a/scripts/templates/containerd-hosts.harbor.example.toml
+++ b/scripts/templates/containerd-hosts.harbor.example.toml
@@ -1,0 +1,42 @@
+# containerd hosts config template
+#
+# Suggested path layout:
+# - /etc/containerd/certs.d/docker.io/hosts.toml
+# - /etc/containerd/certs.d/ghcr.io/hosts.toml
+# - /etc/containerd/certs.d/quay.io/hosts.toml
+# - /etc/containerd/certs.d/registry.k8s.io/hosts.toml
+# - /etc/containerd/certs.d/gcr.io/hosts.toml
+# - /etc/containerd/certs.d/k8s.gcr.io/hosts.toml
+# - /etc/containerd/certs.d/mcr.microsoft.com/hosts.toml
+#
+# For docker.io, set SERVER to "https://registry-1.docker.io" and project to dockerhub.
+# For ghcr.io, set SERVER to "https://ghcr.io" and project to ghcr.
+# For quay.io, set SERVER to "https://quay.io" and project to quay.
+# For registry.k8s.io, set SERVER to "https://registry.k8s.io" and project to registry-k8s.
+# For gcr.io and k8s.gcr.io, set project to gcr.
+# For mcr.microsoft.com, set project to mcr.
+#
+# Replace placeholders before use:
+# - __SERVER__
+# - harbor.isning.moe (already set in this template)
+# - __HARBOR_PROJECT__      (dockerhub or ghcr)
+# - __HARBOR_USERNAME__
+# - __HARBOR_PASSWORD__
+#
+# After writing hosts.toml files, restart containerd:
+#   sudo systemctl restart containerd
+
+server = "__SERVER__"
+
+[host."https://harbor.isning.moe/v2/__HARBOR_PROJECT__"]
+  capabilities = ["pull", "resolve"]
+  override_path = true
+  skip_verify = false
+
+  [host."https://harbor.isning.moe/v2/__HARBOR_PROJECT__".header]
+    authorization = "Basic __BASE64_HARBOR_CREDENTIALS__"
+
+# Optional fallback to upstream if Harbor cache is unavailable.
+# Uncomment if you prefer availability over strict cache-only behavior.
+# [host."__SERVER__"]
+#   capabilities = ["pull", "resolve"]

--- a/scripts/templates/k3s-registries.harbor.example.yaml
+++ b/scripts/templates/k3s-registries.harbor.example.yaml
@@ -1,0 +1,69 @@
+# k3s registries mirror config (for /etc/rancher/k3s/registries.yaml)
+#
+# This template routes common upstream registries through Harbor proxy cache projects:
+# - docker.io -> harbor project "dockerhub"
+# - ghcr.io   -> harbor project "ghcr"
+# - quay.io   -> harbor project "quay"
+# - registry.k8s.io -> harbor project "registry-k8s"
+# - gcr.io -> harbor project "gcr"
+# - k8s.gcr.io -> harbor project "gcr"
+# - mcr.microsoft.com -> harbor project "mcr"
+#
+# Replace placeholders before use:
+# - harbor.isning.moe (already set in this template)
+# - __HARBOR_USERNAME__
+# - __HARBOR_PASSWORD__
+#
+# After updating this file on node, restart k3s:
+#   sudo systemctl restart k3s
+
+mirrors:
+  docker.io:
+    endpoint:
+      - "https://harbor.isning.moe"
+    rewrite:
+      "^(.*)$": "dockerhub/$1"
+
+  ghcr.io:
+    endpoint:
+      - "https://harbor.isning.moe"
+    rewrite:
+      "^(.*)$": "ghcr/$1"
+
+  quay.io:
+    endpoint:
+      - "https://harbor.isning.moe"
+    rewrite:
+      "^(.*)$": "quay/$1"
+
+  registry.k8s.io:
+    endpoint:
+      - "https://harbor.isning.moe"
+    rewrite:
+      "^(.*)$": "registry-k8s/$1"
+
+  gcr.io:
+    endpoint:
+      - "https://harbor.isning.moe"
+    rewrite:
+      "^(.*)$": "gcr/$1"
+
+  k8s.gcr.io:
+    endpoint:
+      - "https://harbor.isning.moe"
+    rewrite:
+      "^(.*)$": "gcr/$1"
+
+  mcr.microsoft.com:
+    endpoint:
+      - "https://harbor.isning.moe"
+    rewrite:
+      "^(.*)$": "mcr/$1"
+
+configs:
+  "harbor.isning.moe":
+    auth:
+      username: "__HARBOR_USERNAME__"
+      password: "__HARBOR_PASSWORD__"
+    tls:
+      insecure_skip_verify: false


### PR DESCRIPTION
- deploy Harbor via Flux HelmRelease and expose harbor.isning.moe route
- route Harbor outbound traffic through proxy-svc egress proxy
- add namespace and overlay wiring for Harbor controller/configs
- add idempotent Harbor API bootstrap script for registries + proxy-cache projects
- add multi-registry mirror templates for k3s/containerd (dockerhub/ghcr/quay/registry.k8s/gcr/mcr)
- refine Harbor mirror README with operations and rotation guidance