### PR TITLE
refactor(configs): move Harbor HTTPRoute to dedicated harbor base

### DIFF
--- a/infra/configs/base/harbor/ingress-route.yaml
+++ b/infra/configs/base/harbor/ingress-route.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
@@ -5,10 +6,9 @@ metadata:
   namespace: harbor
 spec:
   parentRefs:
-    - name: infra-gateway
-      namespace: kube-system
-  hostnames:
-    - "harbor.isning.moe"
+    - name: default-gateway
+      namespace: prod
+  hostnames: ["harbor.isning.moe"]
   rules:
     - matches:
         - path:

--- a/infra/configs/base/harbor/kustomization.yaml
+++ b/infra/configs/base/harbor/kustomization.yaml
@@ -2,5 +2,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ./grafana-loki.yaml
-  - ./vmagent.yaml
+  - ./ingress-route.yaml

--- a/infra/configs/overlays/kubevirt-lab-1/kustomization.yaml
+++ b/infra/configs/overlays/kubevirt-lab-1/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   - ../../base/cert-manager/
   - ../../base/kubevirt/
   - ../../base/gateway/
+  - ../../base/harbor/
   - ../../base/kiali/
   - ../../base/flux/
   - ../../base/cloudnative-pg/


### PR DESCRIPTION
- add infra/configs/base/harbor with ingress-route and kustomization
- remove deprecated harbor route from istio/httproutes
- wire new harbor base into kubevirt-lab-1 configs overlay
- align Harbor routing gateway with current default-gateway pattern