### PR TITLE
fix(apps/clirelay): Change proxy URL scheme from HTTP to SOCKS5

### DIFF
--- a/apps/base/clirelay/config.yaml
+++ b/apps/base/clirelay/config.yaml
@@ -11,7 +11,7 @@ remote-management:
 quota-exceeded:
   switch-preview-model: true
 force-model-prefix: true
-proxy-url: "http://proxy-svc.egress-system.svc.cluster.local:7890"
+proxy-url: "socks5://proxy-svc.egress-system.svc.cluster.local:7890"
 
 # Persist credentials in mounted PVC.
 auth-dir: "/root/.cli-proxy-api"


### PR DESCRIPTION
This should fix
```
failed to create proxy dialer for "http://proxy-svc.egress-system.svc.cluster.local:7890": proxy: unknown scheme: http
```