### PR TITLE
chore(egress-system): pin kubectl image version to `rancher/kubectl:v…

### DIFF
--- a/infra/controllers/base/egress/proxy-engine/restarter/cronjob.yaml
+++ b/infra/controllers/base/egress/proxy-engine/restarter/cronjob.yaml
@@ -19,7 +19,7 @@ spec:
               type: RuntimeDefault
           containers:
           - name: restarter
-            image: bitnami/kubectl:latest
+            image: rancher/kubectl:v1.34.5
             command:
             - /bin/sh
             - -c


### PR DESCRIPTION
…1.34.5`