### PR TITLE
fix: stop pin from OCI repository configurations 

### DIFF
--- a/apps/base/logto/helm-oci-repo.yaml
+++ b/apps/base/logto/helm-oci-repo.yaml
@@ -11,4 +11,3 @@ spec:
   url: oci://ghcr.io/the-ccsn/charts/logto
   ref:
     tag: "0.2.12"
-    digest: "sha256:a94af59e24a0c1631daac45f9375d4f7e7caec9f41a88521917ee9fcd203f0b0"

--- a/infra/controllers/base/altlantis/helm-oci-repo.yaml
+++ b/infra/controllers/base/altlantis/helm-oci-repo.yaml
@@ -12,4 +12,3 @@ spec:
   url: oci://ghcr.io/runatlantis/charts/atlantis
   ref:
     tag: "6.2.0"
-    digest: "sha256:f2adb3d1c6212c796f92d3b9dbbe5f42eea7e4a6d901ac16586423e1c8fda489"

--- a/infra/controllers/base/cert-manager/helm-oci-repo.yaml
+++ b/infra/controllers/base/cert-manager/helm-oci-repo.yaml
@@ -12,4 +12,3 @@ spec:
   url: oci://quay.io/jetstack/charts/cert-manager
   ref:
     tag: "1.20.2"
-    digest: "sha256:294a761ca972ea11ae79b9219960ca13a5337a1cbb550604c151586d266159eb"

--- a/infra/controllers/base/cloudnative-pg/helm-oci-repo.yaml
+++ b/infra/controllers/base/cloudnative-pg/helm-oci-repo.yaml
@@ -12,4 +12,3 @@ spec:
   url: oci://ghcr.io/cloudnative-pg/charts/cloudnative-pg
   ref:
     tag: "0.28.0"
-    digest: "sha256:d216a2b1e3c1ea04e0baff88fff91d768cb1f4f21f83b1a8a6d620bcdf85435f"

--- a/infra/controllers/base/grafana-operator/helm-oci-repo.yaml
+++ b/infra/controllers/base/grafana-operator/helm-oci-repo.yaml
@@ -12,4 +12,3 @@ spec:
   url: oci://ghcr.io/grafana/helm-charts/grafana-operator
   ref:
     tag: "5.22.2"
-    digest: "sha256:8cb589d52db1d1de3fec53078bc7f0547c4132d2bb309c6fc7645e8010fd4bfa"

--- a/infra/controllers/base/istio/helm-oci-repo.yaml
+++ b/infra/controllers/base/istio/helm-oci-repo.yaml
@@ -12,7 +12,6 @@ spec:
   url: oci://gcr.dockerproxy.net/istio-release/charts/base
   ref:
     tag: "1.29.2"
-    digest: "sha256:94f3ec5ce77ed25df771dd8431622fe56d986dc0fcc3386a91c8faf7eb58d425"
 ---
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: OCIRepository
@@ -27,7 +26,6 @@ spec:
   url: oci://gcr.dockerproxy.net/istio-release/charts/cni
   ref:
     tag: "1.29.2"
-    digest: "sha256:a9a6eb8f53124e18a49171d80e8eab57852bc778c3165e2434cc7fa21f43f662"
 ---
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: OCIRepository
@@ -42,7 +40,6 @@ spec:
   url: oci://gcr.dockerproxy.net/istio-release/charts/ztunnel
   ref:
     tag: "1.29.2"
-    digest: "sha256:6046ea57e28e2d7c289abd9db5f9709bd3aac0c771d077aeb39634da3c7e5fea"
 ---
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: OCIRepository
@@ -57,4 +54,3 @@ spec:
   url: oci://gcr.dockerproxy.net/istio-release/charts/istiod
   ref:
     tag: "1.29.2"
-    digest: "sha256:9b20c3cd533008fd3624b44a68cb428820c388293db95221886c69606cd2cd28"

--- a/infra/controllers/base/k6/helm-oci-repo.yaml
+++ b/infra/controllers/base/k6/helm-oci-repo.yaml
@@ -12,4 +12,3 @@ spec:
   url: oci://ghcr.io/grafana/helm-charts/k6-operator
   ref:
     tag: "4.3.2"
-    digest: "sha256:6623d3188ac5c12ab101ac99aa05c8853405cc0a93215c92fa3499f8d7197ac1"

--- a/infra/controllers/base/kiali/helm-oci-repo.yaml
+++ b/infra/controllers/base/kiali/helm-oci-repo.yaml
@@ -12,4 +12,3 @@ spec:
   url: oci://ghcr.io/isning/charts-mirror/kiali-operator
   ref:
     tag: "2.24.0"
-    digest: "sha256:accaae542b6204cfaf2e122386771c1911454b54f2ec35db3306826b351268d2"

--- a/infra/controllers/base/loki/helm-oci-repo.yaml
+++ b/infra/controllers/base/loki/helm-oci-repo.yaml
@@ -12,4 +12,3 @@ spec:
   url: oci://ghcr.io/grafana/helm-charts/loki
   ref:
     tag: "6.55.0"
-    digest: "sha256:ab6e6711db093392b61c57de63a9e5dd82f185011a2f64144d5239ca63864ce7"

--- a/infra/controllers/base/oauth2-proxy/helm-oci-repo.yaml
+++ b/infra/controllers/base/oauth2-proxy/helm-oci-repo.yaml
@@ -12,4 +12,3 @@ spec:
   url: oci://ghcr.io/oauth2-proxy/charts/oauth2-proxy
   ref:
     tag: "10.4.3"
-    digest: "sha256:8628835e87c24230f59942298663eb6544b285ea0fbbd4370a1882143b065c0e"

--- a/infra/controllers/base/otel-collector/helm-oci-repo.yaml
+++ b/infra/controllers/base/otel-collector/helm-oci-repo.yaml
@@ -12,4 +12,3 @@ spec:
   url: oci://ghcr.io/open-telemetry/opentelemetry-helm-charts/opentelemetry-collector
   ref:
     tag: "0.150.1"
-    digest: "sha256:3cafeed02edec3fd9e357766cb705fa257146ef60c8bf4a7ea1e48eae37caaae"

--- a/infra/controllers/base/redroid-operator/helm-oci-repo.yaml
+++ b/infra/controllers/base/redroid-operator/helm-oci-repo.yaml
@@ -12,4 +12,3 @@ spec:
   url: oci://ghcr.io/isning/charts/redroid-operator
   ref:
     tag: "0.1.7"
-    digest: "sha256:9a69ff3b8f680bda5c9f0f4d5e2db7f3f89c2ff483e9ae6c921ac1cf4e6e00fb"

--- a/infra/controllers/base/victoria-metrics/helm-oci-repo.yaml
+++ b/infra/controllers/base/victoria-metrics/helm-oci-repo.yaml
@@ -12,4 +12,3 @@ spec:
   url: oci://ghcr.io/victoriametrics/helm-charts/victoria-metrics-k8s-stack
   ref:
     tag: "0.74.1"
-    digest: "sha256:dbf189a348da62eee412015d834b8eefc09c5a351255bdfb0d1c99a579db3f66"

--- a/infra/controllers/base/victoria-metrics/prometheus-operator-crds/helm-oci-repo.yaml
+++ b/infra/controllers/base/victoria-metrics/prometheus-operator-crds/helm-oci-repo.yaml
@@ -13,4 +13,3 @@ spec:
   url: oci://ghcr.io/prometheus-community/charts/prometheus-operator-crds
   ref:
     tag: "28.0.1"
-    digest: "sha256:8e4de9813563f5bd7c0b17e413e5cd57bee9c94c5dec3f0c607ff72622172e1e"

--- a/infra/pre-controllers/base/cilium/helm-oci-repo.yaml
+++ b/infra/pre-controllers/base/cilium/helm-oci-repo.yaml
@@ -12,4 +12,3 @@ spec:
   url: oci://quay.io/cilium/charts/cilium
   ref:
     tag: "1.19.3"
-    digest: "sha256:0683e1fc672e0c6587a8d8d43f6845430aaaed47e36dacbe77e3e621ea7a4c69"

--- a/infra/pre-controllers/base/flux/helm-oci-repo.yaml
+++ b/infra/pre-controllers/base/flux/helm-oci-repo.yaml
@@ -12,4 +12,3 @@ spec:
   url: oci://ghcr.io/controlplaneio-fluxcd/charts/flux-operator
   ref:
     tag: "0.47.0"
-    digest: "sha256:a0bcc6ff0cbf1d825ba15afc7565b36786fd0a10b3c567d7008e0ca4dec12a7d"

--- a/infra/pre-controllers/base/local-path-provisioner/helm-oci-repo.yaml
+++ b/infra/pre-controllers/base/local-path-provisioner/helm-oci-repo.yaml
@@ -12,4 +12,3 @@ spec:
   url: oci://ghcr.io/rancher/local-path-provisioner/charts/local-path-provisioner
   ref:
     tag: "0.0.35"
-    digest: "sha256:e55542fbcaabca60400efd544a5554dff27e570e1864633d4efe14406d7fda23"

--- a/renovate.json
+++ b/renovate.json
@@ -24,6 +24,11 @@
     {
       "matchPackageNames": ["adyanth/cloudflare-operator"],
       "allowedVersions": "!/^(10|10\\.0|10\\.0\\.2)$/"
+    },
+    {
+        "matchManagers": ["flux"],
+        "matchDatasources": ["docker"],
+        "pinDigests": false
     }
   ]
 }


### PR DESCRIPTION
Since renovate dont like it before this to be fixed:
https://github.com/renovatebot/renovate/issues/42082