### PR TITLE
fix(lock): make multi-arch archive hash reproducible

### DIFF
--- a/lib/mkMultiArchImageArchive.nix
+++ b/lib/mkMultiArchImageArchive.nix
@@ -20,16 +20,21 @@ pkgs.runCommand "${safeName}-${safeTag}-${safeDigest}.tar"
     outputHash = archiveHash;
     nativeBuildInputs = [
       pkgs.skopeo
+      pkgs.gnutar
     ];
   }
   ''
     success=0
+    imageDir="$TMPDIR/image-dir"
+
     for sourceImage in ${lib.concatStringsSep " " (map lib.escapeShellArg sourceImages)}; do
       attempt=1
       while [ "$attempt" -le ${toString mirrorRetries} ]; do
-        if skopeo --tmpdir "$TMPDIR" copy --insecure-policy --multi-arch all \
+        rm -rf "$imageDir"
+        echo "[mkMultiArchImageArchive] skopeo copy attempt=$attempt/${toString mirrorRetries} source=docker://$sourceImage@${imageDigest} dest=dir:$imageDir flags=--insecure-policy --multi-arch all --preserve-digests" >&2
+        if skopeo --tmpdir "$TMPDIR" copy --insecure-policy --multi-arch all --preserve-digests \
           "docker://$sourceImage@${imageDigest}" \
-          "oci-archive:$out:${finalImageName}:${finalImageTag}"; then
+          "dir:$imageDir"; then
           success=1
           break
         fi
@@ -44,4 +49,16 @@ pkgs.runCommand "${safeName}-${safeTag}-${safeDigest}.tar"
       echo "Failed to fetch ${finalImageName}@${imageDigest} from all sources after retries." >&2
       exit 1
     fi
+
+    tar \
+      --create \
+      --file="$out" \
+      --owner=0 \
+      --group=0 \
+      --numeric-owner \
+      --format=gnu \
+      --sort=name \
+      --mtime="@$SOURCE_DATE_EPOCH" \
+      -C "$imageDir" \
+      .
   ''


### PR DESCRIPTION
Switch skopeo intermediate output to dir transport with --preserve-digests and normalize tar packaging metadata to stabilize fixed-output hashes across retries and mirrors.