### PR TITLE
fix(harbor): avoid cross-namespace sourceRef for tofu terraform

### DIFF
--- a/infra/configs/base/harbor/git-repository.yaml
+++ b/infra/configs/base/harbor/git-repository.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: harbor-config
+  namespace: harbor
+spec:
+  interval: 5m
+  url: https://github.com/isning/k8s-gitops
+  ref:
+    branch: main

--- a/infra/configs/base/harbor/kustomization.yaml
+++ b/infra/configs/base/harbor/kustomization.yaml
@@ -2,6 +2,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - ./git-repository.yaml
   - ./ingress-route.yaml
   - ./tofu-terraform.yaml
   - ./harbor-k8s-robot-account-auth-secret.yaml

--- a/infra/configs/base/harbor/tofu-terraform.yaml
+++ b/infra/configs/base/harbor/tofu-terraform.yaml
@@ -10,8 +10,7 @@ spec:
   path: ./infra/configs/base/harbor/tf
   sourceRef:
     kind: GitRepository
-    name: flux-system
-    namespace: flux-system
+    name: harbor-config
   retryInterval: 1m
   runnerPodTemplate:
     spec:


### PR DESCRIPTION
Create a GitRepository in the harbor namespace and point Terraform sourceRef to it so reconciliation works when cross-namespace references are disabled.
