### PR TITLE
fix(harbor): use varsFrom instead of TF_VAR env injection

### DIFF
--- a/infra/configs/base/harbor/tofu-terraform.yaml
+++ b/infra/configs/base/harbor/tofu-terraform.yaml
@@ -11,19 +11,16 @@ spec:
   sourceRef:
     kind: GitRepository
     name: harbor-config
+  vars:
+    - name: harbor_username
+      value: admin
+  varsFrom:
+    - kind: Secret
+      name: harbor-admin-auth
+      varsKeys:
+        - HARBOR_ADMIN_PASSWORD:harbor_password
+    - kind: Secret
+      name: harbor-k8s-robot-account-auth
+      varsKeys:
+        - password:robot_account_k8s_secret
   retryInterval: 1m
-  runnerPodTemplate:
-    spec:
-      env:
-        - name: TF_VAR_harbor_username
-          value: admin
-        - name: TF_VAR_harbor_password
-          valueFrom:
-            secretKeyRef:
-              name: harbor-admin-auth
-              key: HARBOR_ADMIN_PASSWORD
-        - name: TF_VAR_robot_account_k8s_secret
-          valueFrom:
-            secretKeyRef:
-              name: harbor-k8s-robot-account-auth
-              key: password

--- a/scripts/templates/README-harbor-mirror.md
+++ b/scripts/templates/README-harbor-mirror.md
@@ -46,10 +46,11 @@ Proxy-cache registries/projects are managed by `tofu-controller` + Terraform:
 
 Terraform runs in namespace `harbor` and reuses Harbor's existing admin password secret.
 
-- `TF_VAR_harbor_username` is set to `admin` in `Terraform` CR
-- `TF_VAR_harbor_password` is read from secret `harbor-admin-auth`, key `HARBOR_ADMIN_PASSWORD`
+- `harbor_username` is set to `admin` via `spec.vars` in `Terraform` CR
+- `harbor_password` is read from secret `harbor-admin-auth` via `spec.varsFrom`
+- `robot_account_k8s_secret` is read from secret `harbor-k8s-robot-account-auth` via `spec.varsFrom`
 
-If you need upstream registry credentials, add them as env vars in the `Terraform` CR runner pod.
+If you need upstream registry credentials, add them via `spec.varsFrom` (recommended) or `spec.vars` in the `Terraform` CR.
 
 ## k3s
 


### PR DESCRIPTION
Move Harbor Terraform inputs to spec.vars/spec.varsFrom and remove manual TF_VAR_* runner env settings that are rejected by tofu-controller.
