### PR TITLE
fix(harbor): configure tofu runner proxy for provider download

### DIFF
--- a/infra/configs/base/harbor/tofu-terraform.yaml
+++ b/infra/configs/base/harbor/tofu-terraform.yaml
@@ -24,3 +24,12 @@ spec:
       varsKeys:
         - password:robot_account_k8s_secret
   retryInterval: 1m
+  runnerPodTemplate:
+    spec:
+      env:
+        - name: HTTP_PROXY
+          value: http://proxy-svc.egress-system.svc.cluster.local:7890
+        - name: HTTPS_PROXY
+          value: http://proxy-svc.egress-system.svc.cluster.local:7890
+        - name: NO_PROXY
+          value: 127.0.0.1,localhost,.svc,.cluster.local


### PR DESCRIPTION
Set HTTP_PROXY/HTTPS_PROXY/NO_PROXY on the Terraform runner pod template so OpenTofu can fetch provider release artifacts in restricted egress environments.