### PR TITLE
feat(apps): add siyuan service with pinned image and route

### DIFF
--- a/apps/base/siyuan/deployment.yaml
+++ b/apps/base/siyuan/deployment.yaml
@@ -1,0 +1,54 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: siyuan
+  labels:
+    app: siyuan
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: siyuan
+  template:
+    metadata:
+      labels:
+        app: siyuan
+    spec:
+      containers:
+        - name: siyuan
+          image: b3log/siyuan:v3.6.5@sha256:1a316554bfbf0c951ddabc7d3cb0292620152b44c087b6979d5d9b6bae065b1b
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 6806
+          env:
+            - name: TZ
+              value: "Asia/Shanghai"
+          resources:
+            requests:
+              cpu: 10m
+              memory: 10Mi
+            limits:
+              cpu: 100m
+              memory: 512Mi
+          volumeMounts:
+            - name: siyuan-workspace
+              mountPath: /siyuan/workspace
+      volumes:
+        - name: siyuan-workspace
+          persistentVolumeClaim:
+            claimName: siyuan-workspace-pvc
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: siyuan
+  labels:
+    app: siyuan
+spec:
+  selector:
+    app: siyuan
+  ports:
+    - name: http
+      port: 6806
+      targetPort: 6806

--- a/apps/base/siyuan/httproute.yaml
+++ b/apps/base/siyuan/httproute.yaml
@@ -1,0 +1,21 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: siyuan
+  labels:
+    app: siyuan
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: default-gateway
+  hostnames:
+    - "note.isning.moe"
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: siyuan
+          port: 6806

--- a/apps/base/siyuan/kustomization.yaml
+++ b/apps/base/siyuan/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./pvc.yaml
+  - ./deployment.yaml
+  - ./httproute.yaml

--- a/apps/base/siyuan/pvc.yaml
+++ b/apps/base/siyuan/pvc.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: siyuan-workspace-pvc
+  labels:
+    app: siyuan
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+    limits:
+      storage: 10Gi

--- a/apps/overlays/kubevirt-lab-1/prod/kustomization.yaml
+++ b/apps/overlays/kubevirt-lab-1/prod/kustomization.yaml
@@ -11,4 +11,5 @@ resources:
   - ./../../../base/astrbot/
   - ./../../../base/clirelay/
   - ./../../../base/speaches/
+  - ./../../../base/siyuan/
   # - ./../../../base/maa/


### PR DESCRIPTION
Add Siyuan base manifests with constrained resources and persistent storage, expose it at note.isning.moe, and include it in the kubevirt-lab-1 prod overlay.
