### PR TITLE
fix(proxy-engine): use full image name for python

### DIFF
--- a/infra/controllers/base/egress/proxy-engine/deployment.yaml
+++ b/infra/controllers/base/egress/proxy-engine/deployment.yaml
@@ -21,7 +21,7 @@ spec:
           type: RuntimeDefault
       initContainers:
       - name: fetch-nodes
-        image: python:3.14-alpine@sha256:dd4d2bd5b53d9b25a51da13addf2be586beebd5387e289e798e4083d94ca837a
+        image: docker.io/library/python:3.14-alpine@sha256:dd4d2bd5b53d9b25a51da13addf2be586beebd5387e289e798e4083d94ca837a
         envFrom:
         - secretRef:
             name: sub-converter-suburls-secret


### PR DESCRIPTION
because emitting prefix causes failure on matching it with image imported