### PR TITLE
fix(renovate): continue to pin flux oci digest

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -26,11 +26,6 @@
       "allowedVersions": "!/^(10|10\\.0|10\\.0\\.2)$/"
     },
     {
-      "matchManagers": ["flux"],
-      "matchDatasources": ["docker"],
-      "pinDigests": false
-    },
-    {
       "description": "Bump tofu runner tags",
       "matchPackageNames": ["ghcr.io/isning/k8s-gitops/tf-runner"],
       "allowedVersions": "/^v\\d+\\.\\d+\\.\\d+-custom-\\d{12}$/",


### PR DESCRIPTION
Since
https://github.com/renovatebot/renovate/issues/42082 has been fixed